### PR TITLE
Server_Status & Disable_AD/LDAP_User Procedures (JS 1 0 0 0)

### DIFF
--- a/User_Procedures/Server_Status/README.md
+++ b/User_Procedures/Server_Status/README.md
@@ -25,7 +25,7 @@ You'll find the procedure appears in the CM Outline window, under Procedure_Outl
 You can always refer to the Procedure related topics in Command Manager Help document for more information.
 
 ## Execution
-EXECUTE PROCEDURE Server_Status("<server_name_string_match>");
+EXECUTE PROCEDURE Server_Status("server_name_string_match");
 
 ## History
 2016-06-27: Initial creation by Jonathan

--- a/User_Procedures/Server_Status/README.md
+++ b/User_Procedures/Server_Status/README.md
@@ -1,0 +1,39 @@
+<snippet>
+# Server Status
+This procedure was created to determine the status of a particular server which could then be grep'd through command line.
+
+One of three values will be returned;
+1. Active
+1. Paused
+1. Stopped
+
+Note that this is a "contains comparison" on the sServerName input. Therefore multiple server's results could be returned if desired.
+
+## Installation
+Copy the applicable procedure to your "User Procedures" folder then restart Command Manager.
+
+Example folder path: C:\Program Files (x86)\MicroStrategy\Command Manager\Outlines\Procedure_Outlines\User_Procedures
+
+## How To Use
+
+Steps to use procedures in this repo:
+
+Clone the repo and copy the procedures you like to {Command Manager folder}/Outlines/Procedure_Outlines/User_Procedure.
+Re-launch Command Manager.
+You'll find the procedure appears in the CM Outline window, under Procedure_Outlines > User_Procedures. The instruction of the procedure will be show in the outline. You can provide parameters according to the Samples and execute the procedure.
+
+You can always refer to the Procedure related topics in Command Manager Help document for more information.
+
+## Execution
+EXECUTE PROCEDURE Server_Status("<server_name_string_match>");
+
+## History
+2016-06-27: Initial creation by Jonathan
+
+## Credits
+Jonathan Smith
+
+## Disclaimer
+We do not guarantee or be responsible for the safety of these procedures. Please evaluate the risk before you use any of them
+
+</snippet>

--- a/User_Procedures/Server_Status/Server_Status.cmp
+++ b/User_Procedures/Server_Status/Server_Status.cmp
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="ISO-8859-1" standalone="no"?>
+<PROCEDURE_DEFINITION>
+<DESCRIPTION>This will return the status of a server as specified in call.</DESCRIPTION>
+<CODE>// Capture the details around all of the servers for the connection&#13;
+ResultSet oServerData = executeCapture("LIST ALL SERVERS IN CLUSTER;");&#13;
+&#13;
+oServerData.moveFirst();&#13;
+while(!oServerData.isEof()){&#13;
+	// set variables from result set&#13;
+	String sServer = oServerData.getFieldValueString(NAME);&#13;
+	String sStatus = oServerData.getFieldValueString(CLUSTERED_SERVER_STATUS);&#13;
+&#13;
+	// check if this is the server we care about&#13;
+	if ( sServer.trim().toLowerCase().indexOf(sServerName.trim().toLowerCase()) &gt;= 0 ) {&#13;
+		// it is, so print out status&#13;
+		printOut("Server " + sServerName + " status: " + sStatus );&#13;
+	}&#13;
+	oServerData.moveNext();&#13;
+}</CODE>
+<SAMPLE/>
+<VERSION>1.0</VERSION>
+<TYPE>CUSTOM</TYPE>
+<INPUT_PARAMS>
+<INPUT INPUT_TYPE="STRING">sServerName</INPUT>
+</INPUT_PARAMS>
+<CLASSPATH/>
+<TEST_INPUT>
+<TEST_INPUT_PARAM/>
+</TEST_INPUT>
+<TEST_CONNECTION_INFO>
+<TEST_PSN_NAME></TEST_PSN_NAME>
+<TEST_USERNAME/>
+<TEST_PASSWORD></TEST_PASSWORD>
+</TEST_CONNECTION_INFO>
+</PROCEDURE_DEFINITION>

--- a/User_Procedures/Update_Disabled_Users/README.md
+++ b/User_Procedures/Update_Disabled_Users/README.md
@@ -1,0 +1,33 @@
+<snippet>
+  <content><![CDATA[
+# ${1:Update Disabled Users}
+This project was started because of SOC requirements (not to mention it just being a good idea) that all internal systems need to ensure users are disabled globally.
+
+Example is when a user leaves the company; all accounts must be disabled. Rather than relying on someone remembering to go into MicroStrategy and disable the user; we build an automated process.
+## Installation
+Copy the applicable procedure to your "User Procedures" folder then restart Command Manager.
+
+Example folder path: C:\Program Files (x86)\MicroStrategy\Command Manager\Outlines\Procedure_Outlines\User_Procedures
+
+## How To Use
+
+Steps to use procedures in this repo:
+
+Clone the repo and copy the procedures you like to {Command Manager folder}/Outlines/Procedure_Outlines/User_Procedure.
+Re-launch Command Manager.
+You'll find the procedure appears in the CM Outline window, under Procedure_Outlines > User_Procedures. The instruction of the procedure will be show in the outline. You can provide parameters according to the Samples and execute the procedure.
+
+You can always refer to the Procedure related topics in Command Manager Help document for more information.
+
+## History
+2016-06-27: Initial creation by Jonathan
+
+## Credits
+Jonathan Smith
+
+## Disclaimer
+We do not guarantee or be responsible for the safety of these procedures. Please evaluate the risk before you use any of them
+
+]]></content>
+  <tabTrigger>readme</tabTrigger>
+</snippet>

--- a/User_Procedures/Update_Disabled_Users/README.md
+++ b/User_Procedures/Update_Disabled_Users/README.md
@@ -1,6 +1,5 @@
 <snippet>
-  <content><![CDATA[
-# ${1:Update Disabled Users}
+# Update Disabled Users
 This project was started because of SOC requirements (not to mention it just being a good idea) that all internal systems need to ensure users are disabled globally.
 
 Example is when a user leaves the company; all accounts must be disabled. Rather than relying on someone remembering to go into MicroStrategy and disable the user; we build an automated process.
@@ -28,6 +27,4 @@ Jonathan Smith
 ## Disclaimer
 We do not guarantee or be responsible for the safety of these procedures. Please evaluate the risk before you use any of them
 
-]]></content>
-  <tabTrigger>readme</tabTrigger>
 </snippet>

--- a/User_Procedures/Update_Disabled_Users/Update_Disabled_AD_User.cmp
+++ b/User_Procedures/Update_Disabled_Users/Update_Disabled_AD_User.cmp
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="ISO-8859-1" standalone="no"?>
+<PROCEDURE_DEFINITION>
+<DESCRIPTION>This procedure will run through every user in the project and if the Active Directory status is Disabled then it will update the user status to disabled in MicroStrategy. It will also print out to the log each user it disables.</DESCRIPTION>
+<CODE>//get all users in the environment&#13;
+ResultSet userList = executeCapture("LIST LOGIN, NTLINK, ENABLED FOR USERS IN GROUP \"Everyone\";");&#13;
+//print how many users there are in the environment&#13;
+printOut("There are " + userList.getRowCount() + " users in MSTR");&#13;
+&#13;
+userList.moveFirst();&#13;
+while(!userList.isEof()){&#13;
+	//pull login, ntlink, and enabled into variables&#13;
+	String sLogin = userList.getFieldValueString(LOGIN);&#13;
+	String sLink = userList.getFieldValueString(NT_LINK);&#13;
+	Boolean benabled = (Boolean)userList.getResultCell(DisplayPropertyEnum.ENABLED).getValue();&#13;
+	//for those users who are enabled and do not have a NTLINK value&#13;
+	if ((benabled == true) &amp;&amp; (sLink == "")) {&#13;
+		//don't mess with any of the users here...administrator || (or) ...&#13;
+		if((sLogin.toLowerCase().indexOf("administrator") &gt;= 0) || (sLogin.toLowerCase().indexOf("wjackson") &gt;= 0)) {&#13;
+			//Do not execute&#13;
+		} else {&#13;
+			//if the sLogin gets to here, the user is enabled in MicroStrategy but does not have an NTLINK (and was not in our exclusion)...so disable the user automatically&#13;
+			execute("ALTER USER \"" + sLogin + "\" DISABLED;");&#13;
+			printOut(sLogin + " has been disabled");&#13;
+		}&#13;
+	} else {&#13;
+		//Do nothing because this user was either disabled or had an NTLINK value&#13;
+	}&#13;
+	userList.moveNext();&#13;
+}</CODE>
+<SAMPLE>EXECUTE PROCEDURE Update_Disabled_AD_User();</SAMPLE>
+<VERSION>1.0</VERSION>
+<TYPE>CUSTOM</TYPE>
+<INPUT_PARAMS/>
+<CLASSPATH/>
+<TEST_INPUT/>
+<TEST_CONNECTION_INFO>
+<TEST_PSN_NAME></TEST_PSN_NAME>
+<TEST_USERNAME></TEST_USERNAME>
+<TEST_PASSWORD></TEST_PASSWORD>
+</TEST_CONNECTION_INFO>
+</PROCEDURE_DEFINITION>

--- a/User_Procedures/Update_Disabled_Users/Update_Disabled_LDAP_User.cmp
+++ b/User_Procedures/Update_Disabled_Users/Update_Disabled_LDAP_User.cmp
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="ISO-8859-1" standalone="no"?>
+<PROCEDURE_DEFINITION>
+<DESCRIPTION>This procedure will run through every user in the project and if the LDAP status is Disabled then it will update the user status to disabled in MicroStrategy. It will also print out to the log each user it disables.</DESCRIPTION>
+<CODE>//get all users in the environment&#13;
+ResultSet userList = executeCapture("LIST LOGIN, LDAPLINK, ENABLED FOR USERS IN GROUP \"Everyone\";");&#13;
+//print how many users there are in the environment&#13;
+printOut("There are " + userList.getRowCount() + " users in MSTR");&#13;
+&#13;
+userList.moveFirst();&#13;
+while(!userList.isEof()){&#13;
+	//pull login, ldap_link, and enabled into variables&#13;
+	String sLogin = userList.getFieldValueString(LOGIN);&#13;
+	String sLink = userList.getFieldValueString(LDAP_LINK);&#13;
+	Boolean benabled = (Boolean)userList.getResultCell(DisplayPropertyEnum.ENABLED).getValue();&#13;
+	//for those users who are enabled and do not have a ldap_link value&#13;
+	if ((benabled == true) &amp;&amp; (sLink == "")) {&#13;
+		//don't mess with any of the users here...administrator || (or) ...&#13;
+		if((sLogin.toLowerCase().indexOf("administrator") &gt;= 0) || (sLogin.toLowerCase().indexOf("wjackson") &gt;= 0)) {&#13;
+			//Do not execute&#13;
+		} else {&#13;
+			//if the sLogin gets to here, the user is enabled in MicroStrategy but does not have an ldap_link (and was not in our exclusion)...so disable the user automatically&#13;
+			execute("ALTER USER \"" + sLogin + "\" DISABLED;");&#13;
+			printOut(sLogin + " has been disabled");&#13;
+		}&#13;
+	} else {&#13;
+		//Do nothing because this user was either disabled or had an ldap_link value&#13;
+	}&#13;
+	userList.moveNext();&#13;
+}</CODE>
+<SAMPLE>EXECUTE PROCEDURE Update_Disabled_LDAP_User();</SAMPLE>
+<VERSION>1.0</VERSION>
+<TYPE>CUSTOM</TYPE>
+<INPUT_PARAMS/>
+<CLASSPATH/>
+<TEST_INPUT/>
+<TEST_CONNECTION_INFO>
+<TEST_PSN_NAME></TEST_PSN_NAME>
+<TEST_USERNAME></TEST_USERNAME>
+<TEST_PASSWORD></TEST_PASSWORD>
+</TEST_CONNECTION_INFO>
+</PROCEDURE_DEFINITION>


### PR DESCRIPTION
Adding two Procedures;
1. Server_Status: Returns the status (Active|Paused|Stopped) for a server name specified.
2. Disable_[AD/LDAP]_User: Checks for a valid NTLINK / LDAP_LINK and if none is present the procedure will disable the user in MicroStrategy as well. This is helpful when trying to keep Authentication systems in sync and users leave your company.

Questions, thoughts, etc.; please feel free to reach out! jonathanofsmith@gmail.com or jonathanofsmith on MSTR Community.
